### PR TITLE
Fix jp large name

### DIFF
--- a/docs/_data/sporticon_definitions.json
+++ b/docs/_data/sporticon_definitions.json
@@ -875,7 +875,7 @@
     "Unicode": "f144",
     "player_id": "",
     "name_en": "Large Ball",
-    "name_ja": "新卓球",
+    "name_ja": "ラージボール",
     "name_aka_en": "",
     "sport_related": "Table Tennis",
     "sport_type": "Table",


### PR DESCRIPTION
- 新卓球→ラージボールに修正
